### PR TITLE
Input event is triggered also when input requests focus

### DIFF
--- a/src/core/FormElementValidator.js
+++ b/src/core/FormElementValidator.js
@@ -11,6 +11,7 @@ import {STATE} from './FormValidatorState';
 import setDomNodeDataAttributeByValidatorState from './../dom/setDomNodeDataAttributeByValidatorState';
 import dispatchNativeEvent from './../dom/dispatchNativeEvent';
 import cancelablePromise from './../async/cancelablePromise';
+import {isIE11} from './../utils/DetectBrowser';
 
 /**
  * @author Mikel Tuesta <mikeltuesta@gmail.com>
@@ -43,7 +44,11 @@ class FormElementValidator {
   }
 
   bindListeners() {
-    this.formElementDomNode.addEventListener('input', this.validateIfChanged, true);
+    // IE11 triggers the event before any input is entered
+    if (!isIE11()) {
+      this.formElementDomNode.addEventListener('input', this.validateIfChanged, true);
+    }
+
     this.formElementDomNode.addEventListener('change', this.validateIfChanged, true);
   }
 

--- a/src/utils/DetectBrowser.js
+++ b/src/utils/DetectBrowser.js
@@ -1,0 +1,14 @@
+/*
+ * This file is part of the Validatory package.
+ *
+ * Copyright (c) 2017-present Friends Of ECMAScript
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+const isIE11 = () => {
+  return !!window.MSInputMethodContext && !!document.documentMode;
+};
+
+export {isIE11};


### PR DESCRIPTION
Only validate when input is changed in IE11 browser.

An alternative method is to check at `validateIfChanged` if the browser is IE11, and if the value is not empty.